### PR TITLE
Changed id_token to access_token in google authentication.    issue #10

### DIFF
--- a/src/auth.service.ts
+++ b/src/auth.service.ts
@@ -143,7 +143,7 @@ export class AuthService {
     private _fetchGoogleUserDetails(){
         let currentUser = this.gauth.currentUser.get();
         let profile = currentUser.getBasicProfile();
-        let idToken = currentUser.getAuthResponse().id_token;
+        let idToken = currentUser.getAuthResponse().access_token;
         return {
             token: idToken,
             uid: profile.getId(),


### PR DESCRIPTION
I think the field "access_token" is useful to be used in others APIs, so I added it to the return value.